### PR TITLE
Fix issues wrt installation as a non-root user

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -34,6 +34,10 @@
     import_role:
       name: geerlingguy.composer
     become: true
+  - name: Ensure we are using composer version 1
+    command: /usr/bin/composer self-update --1
+    become: true
+    changed_when: false
   - name: Add a user to own developer portal site files
     user:
       name: devportal
@@ -50,11 +54,14 @@
     tags:
       - test
   - name: Install Drupal with Apigee Developer Portal Kickstart
+    become: true
     import_role:
       name: geerlingguy.drupal
     environment:
       COMPOSER_MEMORY_LIMIT: -1
   - name: Copy over default settings file to settings
+    become: true
+    become_user: "{{ drupal_core_owner }}"
     copy:
       src: "{{ drupal_core_path }}/sites/default/default.settings.php"
       dest: "{{ drupal_core_path }}/sites/default/settings.php"
@@ -69,6 +76,7 @@
       group: "{{ nginx_user }}"
     failed_when: false
   - name: Add NGINX configuration file for Devportal
+    become: true
     template:
       src: templates/nginx.devportal.conf.j2
       dest: /etc/nginx/conf.d/nginx.devportal.conf
@@ -78,18 +86,31 @@
       chdir: "{{ drupal_core_path }}"
     register: drupal_status
     changed_when: false
-    become: false
+    become: true
   - name: Set Drupal file permissions
     import_role:
       name: drupal-file-permissions
     become: true
   - name: Make settings.php writable during installation
+    become: true
     file:
       path: "{{ drupal_root }}/sites/default/settings.php"
       state: file
       mode: '0660'
     when: "'Drupal bootstrap' not in drupal_status.stdout"
   - name: Add script to system wide profile for environment vars and PATH
+    become: true
     template:
       src: templates/profile-devportal.sh.j2
       dest: /etc/profile.d/devportal.sh
+  - name: Ensure SELinux python utils are present
+    become: true
+    package:
+      name: policycoreutils-python-utils
+      state: present
+  - name: Enable SELinux boolean
+    become: true
+    seboolean:
+      name: httpd_can_network_connect # allows nginx to connect to FPM/MySQL
+      state: yes
+      persistent: yes

--- a/requirements.yml
+++ b/requirements.yml
@@ -9,7 +9,8 @@ roles:
   - name: geerlingguy.repo-epel
     version: 1.3.0
   - name: geerlingguy.drupal
-    version: 3.0.1
+    src: https://github.com/mhitza/ansible-role-drupal
+    version: 3.0.2
   - name: geerlingguy.mysql
     version: 3.1.0
   - name: geerlingguy.composer


### PR DESCRIPTION
Because the playbook has been tested within a docker container where
a root is used as the main account. There have been various locations
that required elevation to a privileged user in order to avoid
permission denied issues. See #9

Since the time when the playbook has been originally written and now,
composer v2 has become the stable version. However, the version of
Drupal used seems to be incompatible with this version of composer at
this point. Relevant snippet of the error:

```
TASK [geerlingguy.drupal : Generate Drupal project with composer package in /tmp/composer-project (this may take a while).] ***
...
- drupal/core-project-message 8.8.x-dev requires composer-plugin-api ^1.1 -> found composer-plugin-api[2.0.0] but it does not match the constraint.\n\nYou are using Composer 2, which some of your plugins seem to be incompatible with. Make sure you update your plugins or report a plugin-issue to ask them to support Composer 2.
...
```

Because of this incompatibility, a separate step has been included to
downgrade the installed version of composer to v1.

The container test also has missed a necessary SELinux boolean that
would restrict the nginx server from connecting to the PHP-FPM service
and MySQL/MariaDB.

geerlingguy.drupal role does not properly set the become_user value
when running the composer installation. See related issue https://github.com/geerlingguy/ansible-role-drupal/issues/82
In order to work around this issue, a fork has been made, which implements the
fix referenced.

In order to upstream the fix on the geerlingguy.drupal role, the project
should be updated to work with Drupal 9.x (if necessary). This switch to
Drupal 9.x has not been made as part of the changes, because that would require
a switch to PHP 7.3 (CentOS 8 VM currently comes with PHP 7.2 and
geerlingguy.php-versions would need to be included).

---
In order to replicate the issue and test the changes I have spun up a VirtualBox VM via Vagrant with the following Vagrantfile

```ruby
# -*- mode: ruby -*-
# vi: set ft=ruby :

Vagrant.configure("2") do |config|
  config.vm.box = "centos/8"
  config.vm.network "private_network", ip: "192.168.50.4"
  config.vm.provider "virtualbox" do |v| 
    v.memory = 2048
    v.cpus = 2 
  end 

  config.vm.network "forwarded_port", guest: 80, host: 8080
end
```

The following hosts.yml file
```yaml
all:
  children:
    webservers:
      hosts:
        localhost:
          ansible_host: 127.0.0.1
          ansible_port: 2222
          ansible_user: vagrant
    dbservers:
      hosts:
        localhost:
          ansible_host: 127.0.0.1
          ansible_port: 2222
          ansible_user: vagrant
```

And the following ansible invocation once the VM has been started

```
$ ansible-playbook -i hosts.yml --private-key .vagrant/machines/default/virtualbox/private_key playbook.yml
```